### PR TITLE
Fix lutron caseta integration

### DIFF
--- a/client/characteristic/type.go
+++ b/client/characteristic/type.go
@@ -15,7 +15,7 @@ type RawCharacteristic struct {
 	Value Value  `json:"value"`
 
 	Type        string   `json:"type"`
-	Events      *int     `json:"ev,omitempty"`
+	Events      *bool    `json:"ev,omitempty"`
 	Permissions []string `json:"perms,omitempty"`
 
 	Format string `json:"format"`

--- a/client/client_characteristics.go
+++ b/client/client_characteristics.go
@@ -38,7 +38,7 @@ type CharacteristicReadResponse struct {
 
 	Type        *string  `json:"type,omitempty"`
 	Status      *int     `json:"status,omitempty"`
-	Events      *int     `json:"ev,omitempty"`
+	Events      *bool    `json:"ev,omitempty"`
 	Permissions []string `json:"perms,omitempty"`
 
 	Format *string `json:"format,omitempty"`

--- a/client/client_characteristics.go
+++ b/client/client_characteristics.go
@@ -153,10 +153,11 @@ func (a *AccessoryClient) SetCharacteristics(ctx context.Context, writeReq *Char
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/hap+json")
 
 	resp, err := a.transport.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("transport.Do: %v", err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
This device was returning the Events flag with characteristics which revealed the data type was wrong. It also rejected requests to set characteristics with the proper content-type set.